### PR TITLE
Replace oraclejdk8 with openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 notifications:
   email:


### PR DESCRIPTION
Replace oraclejdk8 with openjdk8 in .travis.yml